### PR TITLE
fix ts error (could not find a declaration file...)  when using in TS project

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,11 @@
   "main": "dist/index.cjs",
   "module": "dist/index.js",
   "exports": {
-    ".": "./dist/index.js",
+    ".": {
+      "types": "./dist/VueAwesomePaginatePlugin.d.ts",
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
+    },
     "./dist/style.css": "./dist/style.css"
   },
   "browser": {


### PR DESCRIPTION
error TS7016: Could not find a declaration file for module 'vue-awesome-paginate'. '/path/node_modules/vue-awesome-paginate/dist/index.js' implicitly has an 'any' type.
There are types at '/path/node_modules/vue-awesome-paginate/dist/VueAwesomePaginatePlugin.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vue-awesome-paginate' library may need to update its package.json or typings.

fix #18 